### PR TITLE
Small Error in implementing DoublyLinkedList

### DIFF
--- a/05-queue-data-structure/projects/final/src/main/kotlin/linkedlist/DoublyLinkedList.kt
+++ b/05-queue-data-structure/projects/final/src/main/kotlin/linkedlist/DoublyLinkedList.kt
@@ -82,7 +82,7 @@ class DoublyLinkedList<T : Any> {
     val next = node.next
 
     if (prev != null) {
-      prev.next = node.previous
+      prev.next = next
     } else {
       head = next
     }


### PR DESCRIPTION
prev.next = node.previous causes StackOverFlow when implementing DoublyLinkedList individually , the correct implementation should be prev.next = next